### PR TITLE
Fix package name, add exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,20 @@
 {
-  "name": "@illinois-toolkit/ilw-hero",
+  "name": "@illinois-toolkit/ilw-page",
   "private": false,
   "version": "0.9.0",
   "type": "module",
+  "exports": {
+    ".": {
+      "import": "./src/ilw-page.js"
+    }
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build --config vite.build.config.js --emptyOutDir",
     "preview": "vite preview"
   },
   "dependencies": {
-    "lit": "^3.1.2"
+    "lit": "3.1.3"
   },
   "devDependencies": {
     "vite": "^5.2.0"


### PR DESCRIPTION
Fixed the name of the package, added exports, and made the lit dependency use exact versioning. The exports and exact versioning are needed for bundling in the toolkit.